### PR TITLE
Split upx run from the default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ dist/hipio:
 		install \
 		--ghc-options '-fPIC' \
 		--split-objs
+
+dist: dist/hipio
 	upx -q --best --ultra-brute dist/hipio
 
 clean:
 	rm -rf dist
 
-.PHONY: clean
+.PHONY: clean dist

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ make
 
 ### Distribute
 
-Create a tinier binary (2-3mb):
+Make `dist/hipio` tinier (2-3mb):
 
 ```
 make dist

--- a/README.md
+++ b/README.md
@@ -22,3 +22,21 @@ Available options:
   -a RECORD                A record for DOMAIN
   --ns RECORD              NS record for DOMAIN
 ```
+
+## Development
+
+### Build
+
+Create a binary in `dist/hipio`:
+
+```
+make
+```
+
+### Distribute
+
+Create a tinier binary (2-3mb):
+
+```
+make dist
+```


### PR DESCRIPTION
May be a silly change, but since `upx` takes a while to run, it's nice to take it out of the default target.