### PR TITLE
Make hipio compatible with ES 6.x

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import qualified Data.ByteString.Char8 as B8
-import           Data.Text             (Text)
-import qualified Data.Text             as T
-import           Database.Bloodhound   (EsPassword (..), EsUsername (..))
+import qualified Data.ByteString.Char8    as B8
+import           Data.Text                (Text)
+import qualified Data.Text                as T
+import           Database.V5.Bloodhound   (EsPassword (..), EsUsername (..))
 import           Lib
 import           Options.Applicative
 import           Options.Applicative.Text (textOption)

--- a/hipio.cabal
+++ b/hipio.cabal
@@ -1,5 +1,5 @@
 name:                hipio
-version:             0.2.2
+version:             0.3.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/elastic/hipio

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -7,36 +7,36 @@ module Lib
 
 import           Control.Applicative
 import           Control.Concurrent
-import           Control.Exception.Safe     (SomeException, bracketOnError,
-                                             catchAny, handle, tryAny)
+import           Control.Exception.Safe       (SomeException, bracketOnError,
+                                                catchAny, handle, tryAny)
 import           Control.Monad
-import           Control.Monad.IO.Class     (liftIO)
+import           Control.Monad.IO.Class       (liftIO)
 import           Data.Array.Unboxed
-import qualified Data.ByteString            as S
-import qualified Data.ByteString.Base64     as B64
+import qualified Data.ByteString              as S
+import qualified Data.ByteString.Base64       as B64
 import           Data.ByteString.Builder
-import qualified Data.ByteString.Char8      as B8
-import qualified Data.ByteString.Internal   as BI
-import qualified Data.ByteString.Lazy       as SL
-import           Data.Char                  (toLower)
-import           Data.Conduit.Attoparsec    (ParseError (..))
+import qualified Data.ByteString.Char8        as B8
+import qualified Data.ByteString.Internal     as BI
+import qualified Data.ByteString.Lazy         as SL
+import           Data.Char                    (toLower)
+import           Data.Conduit.Attoparsec      (ParseError (..))
 import           Data.IP
 import           Data.Maybe
 import           Data.Monoid
-import           Data.Text                  (Text (..))
-import qualified Data.Text                  as T
-import           Data.Text.Encoding         (decodeUtf8)
+import           Data.Text                    (Text (..))
+import qualified Data.Text                    as T
+import           Data.Text.Encoding           (decodeUtf8)
 import           Data.Word
-import           Database.Bloodhound        (EsPassword, EsUsername)
+import           Database.V5.Bloodhound       (EsPassword, EsUsername)
 import           Log
-import           Log.Backend.ElasticSearch
+import           Log.Backend.ElasticSearch.V5
 import           Log.Backend.StandardOutput
 import           Network.BSD
 import           Network.DNS
-import           Network.Socket             hiding (recvFrom)
+import           Network.Socket               hiding (recvFrom)
 import           Network.Socket.ByteString
 import           System.Environment
-import           System.Random              (randomIO)
+import           System.Random                (randomIO)
 import           System.Timeout
 
 import           Parse
@@ -90,7 +90,7 @@ serveDNS domain port as nss email maybeES = withSocketsDo $ do
             defaultElasticSearchConfig
             { esServer  = url
             , esIndex   = "logs"
-            , esMapping = "log"
+            , esMapping = "_doc"
             , esLogin   = login
             }
       withElasticSearchLogger es randomIO doit

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,9 @@
 resolver: lts-7.12
-packages:
-- '.'
-- location:
-    git: https://github.com/scrive/log.git
-    commit: 5298533b243869220ee585f89187500aba54093f
-  subdirs:
-  - log-elasticsearch
-  extra-dep: true
 extra-deps:
-- log-base-0.7
-- bloodhound-0.12.0.0
+- log-base-0.8.0.0
+- unliftio-core-0.1.2.0
+- bloodhound-0.16.0.0
 - hpqtypes-1.5.1.1
+- log-elasticsearch-0.10.1.0
+- aeson-1.0.1.0
 compiler-check: newer-minor


### PR DESCRIPTION
For bringing the hipio to ES6.x the few core dependencies had to be upgraded:
- log-base-0.8.0.0
- bloodhound-0.16.0.0
- log-elasticsearch-0.10.1.0
- aeson-1.0.1.0

This gave the possibility to talk to latest 6.x version of Elasticsearch.

Since this the quite a jump in supporting backend DB - the version of the
service was bumped up to `0.3.0` as well.

The test suite passes as well:
```bash
hipio-0.3.0: test (suite: hipio-test)
                           
Progress 12/13: hipio-0.3.0
Parse
  parseDomain
    parses "0.0.0.0.hip.io."
    parses "127.0.0.1.hip.io."
    parses "a.127.0.0.1.hip.io."
    parses "0.a.127.0.0.1.hip.io."
    parses "127.0.0.a.127.0.0.1.hip.io."
    parses "0.1.2.3.4.foo.com."
    parses "a.255.1.2.3.4.foo.com."
    parses "255.1.2.3.4.a."
    parses "256.1.2.3.4.a."
    parses "256.1.2.3.4.5.hip.io."
    parses any IP
    parses any domain and IP
    parses any domain and IP with any prefix

Finished in 30.2779 seconds
13 examples, 0 failures
                           
hipio-0.3.0: Test suite hipio-test passed
Completed 13 action(s).    
```

The manual testing was done with ES `Version: 6.8.3` and it seemed to be working as expected. But confirmation from @tylerjl and @mindbat  would be great. 

closes https://github.com/elastic/infra/issues/14410