### PR TITLE
[hipio] Remove Elasticsearch dependencies

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,6 @@ module Main where
 import qualified Data.ByteString.Char8    as B8
 import           Data.Text                (Text)
 import qualified Data.Text                as T
-import           Database.V5.Bloodhound   (EsPassword (..), EsUsername (..))
 import           Lib
 import           Options.Applicative
 import           Options.Applicative.Text (textOption)
@@ -13,18 +12,6 @@ import           System.Environment
 main :: IO ()
 main = do
   opts <- execParser opts
-  esconf <-
-    case optsEsUrl opts of
-      Nothing -> return Nothing
-      Just url -> do
-        mbUN <- lookupEnv "ES_USER"
-        login <-
-          case mbUN of
-            Nothing -> return Nothing
-            Just un -> do
-              !pw <- getEnv "ES_PASS"
-              return $ Just (EsUsername $ T.pack un, EsPassword $ T.pack pw)
-        return $ Just (url, login)
   let ns = case optsNSs opts of
              [] -> [optsDomain opts]
              ns -> ns
@@ -34,7 +21,6 @@ main = do
     (optsAs opts)
     ns
     (optsEmail opts)
-    esconf
  where
    opts = info (helper <*> options)
      ( fullDesc
@@ -48,7 +34,6 @@ main = do
 data Options = Options
   { optsDomain :: String
   , optsPort   :: Int
-  , optsEsUrl  :: Maybe Text
   , optsAs     :: [String]
   , optsNSs    :: [String]
   , optsEmail  :: String
@@ -70,13 +55,6 @@ options =
     <> showDefault
     <> help "Listening port."
     )
-  <*>
-    optional (
-      textOption
-      (  long "es"
-      <> help "Elasticsearch URL for Logging. Set `ES_USER` and `ES_PASS` environment variables for Basic Auth."
-      <> metavar "URL"
-      ))
   <*>
     many (
       strOption

--- a/hipio.cabal
+++ b/hipio.cabal
@@ -1,5 +1,5 @@
 name:                hipio
-version:             0.3.1
+version:             0.4.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/elastic/hipio
@@ -21,14 +21,12 @@ library
                      , attoparsec
                      , base64-bytestring
                      , array
-                     , bloodhound
                      , bytestring
                      , conduit-extra
                      , dns
                      , hostname
                      , iproute
                      , log-base
-                     , log-elasticsearch
                      , network
                      , random
                      , safe-exceptions
@@ -41,7 +39,6 @@ executable hipio
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -O2
   build-depends:       base
                      , hipio
-                     , bloodhound
                      , bytestring
                      , optparse-applicative
                      , optparse-text

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,6 @@ resolver: lts-7.12
 extra-deps:
 - log-base-0.8.0.0
 - unliftio-core-0.1.2.0
-- bloodhound-0.16.0.0
 - hpqtypes-1.5.1.1
-- log-elasticsearch-0.10.1.0
 - aeson-1.0.1.0
 compiler-check: newer-minor


### PR DESCRIPTION
This PR cleans up all the ES deps and remove the code of
elasticsearch logging. From now on we will rely only on stdout logging.

Since there is no `log-elasticsearch` and `bloodhound` anymore the compilation has speeded up a bit 😄 