### PR TITLE
[hipio] flush entire message

### DIFF
--- a/hipio.cabal
+++ b/hipio.cabal
@@ -1,5 +1,5 @@
 name:                hipio
-version:             0.4.0
+version:             0.4.1
 synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/elastic/hipio

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -28,7 +28,7 @@ import qualified Data.Text                    as T
 import           Data.Text.Encoding           (decodeUtf8)
 import           Data.Word
 import           Log
-import           Log.Backend.StandardOutput
+import           Log.Backend.StandardOutput.Bulk
 import           Network.BSD
 import           Network.DNS
 import           Network.Socket               hiding (recvFrom)
@@ -78,7 +78,7 @@ serveDNS domain port as nss email = withSocketsDo $ do
   let doit logger = do
         forkIO $ doUDP addrinfo conf logger
         doTCP addrinfo conf logger
-  withSimpleStdOutLogger doit
+  withBulkStdOutLogger doit
 
 doUDP :: AddrInfo -> Conf -> Logger -> IO ()
 doUDP addrinfo conf logger =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-7.12
 extra-deps:
-- log-base-0.8.0.0
+- log-base-0.8.0.1
 - unliftio-core-0.1.2.0
 - hpqtypes-1.5.1.1
 - aeson-1.0.1.0


### PR DESCRIPTION
Switching to `BulkStdOutLogger` which actually makes sure that buffers are flushed to stdout completely and with support for correct shutdown process (messages flushed on shutdown as well)

fixes: https://github.com/elastic/hipio/issues/8