### PR TITLE
[hipio] use jsonlines for logging output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,12 @@ Available options:
                            admin.example.com
 ```
 
-hipio logs DNS request activity to standard output.
+hipio logs DNS request activity to standard output in the form for [jsonlines](http://jsonlines.org/). Example of the output:
+
+```json
+...
+{"component":"UDP","data":{"from":"127.0.0.1:41612","answer":"10.2.1.1","server":"ec2121e7bdd4","question":"10.2.1.1.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-22 06:01:47","level":"INFO"}
+{"component":"UDP","data":{"from":"127.0.0.1:39803","answer":"10.22.1.3","server":"ec2121e7bdd4","question":"10.22.1.3.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-22 06:01:47","level":"INFO"}
+{"component":"UDP","data":{"from":"127.0.0.1:56574","answer":"10.222.10.2","server":"ec2121e7bdd4","question":"10.222.10.2.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-22 06:01:47","level":"INFO"}
+...
+```

--- a/hipio.cabal
+++ b/hipio.cabal
@@ -1,5 +1,5 @@
 name:                hipio
-version:             0.4.1
+version:             0.5.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/elastic/hipio

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,9 @@
 resolver: lts-7.12
 extra-deps:
-- log-base-0.8.0.1
+- git: https://github.com/olksdr/log.git
+  commit: 4a9f7e56adf052f8331f70a565d5650206be76e5
+  subdirs:
+    - log-base
 - unliftio-core-0.1.2.0
 - hpqtypes-1.5.1.1
 - aeson-1.0.1.0


### PR DESCRIPTION
With this PR we introduce new standardized logging output. 
From now on we will log [jsonlines](http://jsonlines.org/) as an broadly acceptable way to log in containerized world.  

We (hopefully)  temporarily switched to the fork for the logging library, till the upstream PR is merged. 

New output will look like:

```json
{"component":"UDP","data":{"from":"127.0.0.1:41612","answer":"1.2.1.1","server":"ec2121e7bdd4","question":"1.2.1.1.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-22 06:01:47","level":"INFO"}
{"component":"UDP","data":{"from":"127.0.0.1:39803","answer":"1.2.1.1","server":"ec2121e7bdd4","question":"1.2.1.1.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-22 06:01:47","level":"INFO"}
{"component":"UDP","data":{"from":"127.0.0.1:56574","answer":"1.2.1.1","server":"ec2121e7bdd4","question":"1.2.1.1.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-22 06:01:47","level":"INFO"}
``` 

fix: https://github.com/elastic/hipio/issues/7