### PR TITLE
[hipio] use updated version of the log library

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ hipio logs DNS request activity to standard output in the form for [jsonlines](h
 
 ```json
 ...
-{"component":"UDP","data":{"from":"127.0.0.1:41612","answer":"10.2.1.1","server":"ec2121e7bdd4","question":"10.2.1.1.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-22 06:01:47","level":"INFO"}
-{"component":"UDP","data":{"from":"127.0.0.1:39803","answer":"10.22.1.3","server":"ec2121e7bdd4","question":"10.22.1.3.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-22 06:01:47","level":"INFO"}
-{"component":"UDP","data":{"from":"127.0.0.1:56574","answer":"10.222.10.2","server":"ec2121e7bdd4","question":"10.222.10.2.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-22 06:01:47","level":"INFO"}
+{"component":"UDP","domain":[],"time":"2020-09-14T08:19:16.9779543Z","level":"info","message":"","data":{"from":"127.0.0.1:57093","answer":"1.2.1.1","server":"ec2121e7bdd4","question":"1.2.1.1.example.com."}}
 ...
 ```

--- a/hipio.cabal
+++ b/hipio.cabal
@@ -1,5 +1,5 @@
 name:                hipio
-version:             0.5.0
+version:             0.6.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/elastic/hipio

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -78,7 +78,7 @@ serveDNS domain port as nss email = withSocketsDo $ do
   let doit logger = do
         forkIO $ doUDP addrinfo conf logger
         doTCP addrinfo conf logger
-  withBulkStdOutLogger doit
+  withBulkJsonStdOutLogger doit
 
 doUDP :: AddrInfo -> Conf -> Logger -> IO ()
 doUDP addrinfo conf logger =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,6 @@
 resolver: lts-7.12
 extra-deps:
-- git: https://github.com/olksdr/log.git
-  commit: 4a9f7e56adf052f8331f70a565d5650206be76e5
-  subdirs:
-    - log-base
+- log-base-0.9.0.0
 - unliftio-core-0.1.2.0
 - hpqtypes-1.5.1.1
 - aeson-1.0.1.0


### PR DESCRIPTION
Updated version of the log library provides proper way to log the jsonlines. We don't need to use our own fork anymore. 

The format of the output is following:

```json
{"component":"UDP","domain":[],"time":"2020-09-12T05:40:48.2790793Z","level":"info","message":"","data":{"from":"127.0.0.1:59461","answer":"1.2.1.1","server":"ec2121e7bdd4","question":"1.2.1.1.example.com."}}
```